### PR TITLE
Fix typo in Country-Timezone pivot config key

### DIFF
--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -87,7 +87,7 @@ class Country extends BaseModel
     {
         return $this->belongsToMany(
             related: Timezone::class,
-            table: config()->string('atlas.country_timezon_pivot_tablename'),
+            table: config()->string('atlas.country_timezone_pivot_tablename'),
             foreignPivotKey: 'country_id',
             relatedPivotKey: 'time_zone_name',
             parentKey: 'id',


### PR DESCRIPTION
## Summary
- Fixed typo in `Country::timezones()` relationship: `country_timezon_pivot_tablename` → `country_timezone_pivot_tablename`

Closes #17