### PR TITLE
Fix pivot column name mismatch in Country-Timezone relationship

### DIFF
--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -89,7 +89,7 @@ class Country extends BaseModel
             related: Timezone::class,
             table: config()->string('atlas.country_timezone_pivot_tablename'),
             foreignPivotKey: 'country_id',
-            relatedPivotKey: 'time_zone_name',
+            relatedPivotKey: 'timezone_name',
             parentKey: 'id',
             relatedKey: 'zone_name'
         );

--- a/src/Models/Timezone.php
+++ b/src/Models/Timezone.php
@@ -33,7 +33,7 @@ class Timezone extends BaseModel
         return $this->belongsToMany(
             related: Country::class,
             table: config()->string('atlas.country_timezone_pivot_tablename'),
-            foreignPivotKey: 'time_zone_name',
+            foreignPivotKey: 'timezone_name',
             relatedPivotKey: 'country_id',
             parentKey: 'zone_name',
             relatedKey: 'id'


### PR DESCRIPTION
## Summary
- Changed `time_zone_name` → `timezone_name` in `Country::timezones()` (`relatedPivotKey`) and `Timezone::countries()` (`foreignPivotKey`) to match the migration column name

Closes #18