### PR TITLE
Fix Country->Currency relationship from HasOne to BelongsTo

### DIFF
--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-
 /**
  * @property int                   $id
  * @property string                $name


### PR DESCRIPTION
## Summary
- Changed `currency()` from `HasOne` to `BelongsTo` using `currency_code`/`code` keys to match the actual schema
- Removed unused `HasOne` import

Closes #19