### PR TITLE
Fix Currency->Country relationship from BelongsTo to HasMany

### DIFF
--- a/src/Models/Currency.php
+++ b/src/Models/Currency.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Raiolanetworks\Atlas\Models;
 
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Currency extends BaseModel
 {
@@ -26,11 +26,11 @@ class Currency extends BaseModel
     }
 
     /**
-     * @return BelongsTo<Country,covariant self>
+     * @return HasMany<Country,covariant self>
      */
-    public function country(): BelongsTo
+    public function countries(): HasMany
     {
-        return $this->belongsTo(Country::class);
+        return $this->hasMany(Country::class, 'currency_code', 'code');
     }
 
     /**


### PR DESCRIPTION
## Summary
- Changed `country()` `BelongsTo` to `countries()` `HasMany` with keys `currency_code`/`code` to match the actual schema
- Multiple countries can share the same currency (e.g., EUR, USD)

Closes #20