### PR TITLE
Add missing $incrementing and $keyType for string PKs

### DIFF
--- a/src/Models/Currency.php
+++ b/src/Models/Currency.php
@@ -10,6 +10,10 @@ class Currency extends BaseModel
 {
     protected $primaryKey = 'code';
 
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
     protected $guarded = [];
 
     public $timestamps = false;

--- a/src/Models/Timezone.php
+++ b/src/Models/Timezone.php
@@ -15,6 +15,10 @@ class Timezone extends BaseModel
 
     protected $primaryKey = 'zone_name';
 
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
     public $timestamps = false;
 
     /**


### PR DESCRIPTION
## Summary
- Added `$incrementing = false` and `$keyType = 'string'` to `Timezone` and `Currency` models
- Both models use string primary keys (`zone_name` and `code`) but were missing the Eloquent configuration, causing `find()`, `findOrFail()`, and route model binding to fail

Closes #21