### PR TITLE
Fix getSingular() match expression and Install command

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -59,7 +59,7 @@ class Install extends Command
         // Call necessary seeders
         foreach ($choice as $value) {
             $lower   = Str::lower(strval($value));
-            $command = 'atlas:' . EntitiesEnum::from($lower)->getSingular();
+            $command = 'atlas:' . EntitiesEnum::from($lower)->value;
 
             $this->newLine();
             $this->line('Seeding ' . $lower . '...');

--- a/src/Enum/EntitiesEnum.php
+++ b/src/Enum/EntitiesEnum.php
@@ -22,16 +22,15 @@ enum EntitiesEnum: string
 
     public function getSingular(): ?string
     {
-        return match ($this->getLabel()) {
-            self::Languages->value  => 'language',
-            self::Currencies->value => 'currency',
-            self::Regions->value    => 'region',
-            self::Subregions->value => 'subregion',
-            self::Countries->value  => 'country',
-            self::States->value     => 'state',
-            self::Cities->value     => 'city',
-            self::Timezones->value  => 'timezone',
-            default                 => $this->value
+        return match ($this) {
+            self::Languages  => 'language',
+            self::Currencies => 'currency',
+            self::Regions    => 'region',
+            self::Subregions => 'subregion',
+            self::Countries  => 'country',
+            self::States     => 'state',
+            self::Cities     => 'city',
+            self::Timezones  => 'timezone',
         };
     }
 


### PR DESCRIPTION
## Summary
- Fixed `getSingular()` in `EntitiesEnum`: was matching `$this->getLabel()` (PascalCase) against `->value` (lowercase), so it always fell to `default`. Now matches on `$this` directly.
- Updated `Install.php` to use `->value` (plural) instead of `->getSingular()` since all seeder commands use plural names (`atlas:countries`, `atlas:timezones`, etc.)

Closes #22