### PR TITLE
Remove unconditional country_id from City::fromJsonToDBRecord

### DIFF
--- a/src/Models/City.php
+++ b/src/Models/City.php
@@ -63,7 +63,6 @@ class City extends BaseModel
             'name'         => $jsonItem['name'],
             'state_code'   => $jsonItem['state_code'],
             'state_name'   => $jsonItem['state_name'],
-            'country_id'   => $jsonItem['country_id'],
             'country_code' => $jsonItem['country_code'],
             'country_name' => $jsonItem['country_name'],
             'latitude'     => $jsonItem['latitude'],


### PR DESCRIPTION
## Summary
- Removed `country_id` from the base array in `City::fromJsonToDBRecord()` so it is only included when the `countries` entity is enabled via config
- Prevents foreign key constraint violations when the countries table doesn't exist

Closes #23