### PR TITLE
Disable FK constraints before truncating tables in BaseSeeder

### DIFF
--- a/src/Commands/Seeders/BaseSeeder.php
+++ b/src/Commands/Seeders/BaseSeeder.php
@@ -6,6 +6,7 @@ namespace Raiolanetworks\Atlas\Commands\Seeders;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Iterator;
 use Raiolanetworks\Atlas\Helpers\ResourcesManager;
@@ -121,7 +122,9 @@ abstract class BaseSeeder extends Command
     protected function seed(): bool
     {
         $existsWhenRecordInsertedMethod = $this->existsWhenRecordInsertedMethod();
+        Schema::disableForeignKeyConstraints();
         $this->model::truncate();
+        Schema::enableForeignKeyConstraints();
         $bar = $this->output->createProgressBar(count($this->data));
         $bar->start();
 


### PR DESCRIPTION
## Summary
- Wrapped `truncate()` call with `Schema::disableForeignKeyConstraints()` / `Schema::enableForeignKeyConstraints()` to prevent SQL errors when re-seeding tables that have foreign key references

Closes #24