### PR TITLE
Wrap seed operation in a database transaction

### DIFF
--- a/src/Commands/Seeders/BaseSeeder.php
+++ b/src/Commands/Seeders/BaseSeeder.php
@@ -123,7 +123,7 @@ abstract class BaseSeeder extends Command
     protected function seed(): bool
     {
         $existsWhenRecordInsertedMethod = $this->existsWhenRecordInsertedMethod();
-        $bar = $this->output->createProgressBar(count($this->data));
+        $bar                            = $this->output->createProgressBar(count($this->data));
         $bar->start();
 
         try {


### PR DESCRIPTION
## Summary
- Wrapped truncate + data insertion in `DB::transaction()` so that if an error occurs mid-seeding, changes are rolled back and the table is not left in an inconsistent state
- Especially important for large seeders like cities (~150k+ records)

Closes #25