### PR TITLE
Remove ini_set memory_limit -1 from Update command

### DIFF
--- a/src/Commands/Update.php
+++ b/src/Commands/Update.php
@@ -38,8 +38,6 @@ class Update extends Command
      */
     public function handle(): int
     {
-        ini_set('memory_limit', '-1');
-
         $this->info('Updating data of countries, cities, currencies, languages, states and timezones');
 
         if (! $this->checkRequiredTables()) {


### PR DESCRIPTION
## Summary
- Removed `ini_set('memory_limit', '-1')` from `Update::handle()` — this command only checks table existence and does not load JSON files, so unlimited memory is unnecessary

Closes #27