### PR TITLE
Optimize TimezonesSeeder with pre-built zone-to-countries index

### DIFF
--- a/src/Commands/Seeders/TimezonesSeeder.php
+++ b/src/Commands/Seeders/TimezonesSeeder.php
@@ -42,6 +42,11 @@ class TimezonesSeeder extends BaseSeeder
      */
     protected array $data;
 
+    /**
+     * @var array<string, list<int>>
+     */
+    private array $timezoneCountries = [];
+
     public function __construct()
     {
         parent::__construct();
@@ -66,6 +71,12 @@ class TimezonesSeeder extends BaseSeeder
         }
 
         $this->data = $data;
+
+        foreach ($this->data as $rawCountry) {
+            foreach ($rawCountry['timezones'] as $rawTimezone) {
+                $this->timezoneCountries[$rawTimezone['zoneName']][] = $rawCountry['id'];
+            }
+        }
 
         return true;
     }
@@ -93,14 +104,8 @@ class TimezonesSeeder extends BaseSeeder
 
     protected function whenRecordInserted(Timezone $instance): void
     {
-        foreach ($this->data as $rawCountry) {
-            foreach ($rawCountry['timezones'] as $rawTimezone) {
-                if ($rawTimezone['zoneName'] === $instance->zone_name) {
-                    $instance->countries()->attach($rawCountry['id']);
-
-                    continue 2;
-                }
-            }
+        if (isset($this->timezoneCountries[$instance->zone_name])) {
+            $instance->countries()->attach($this->timezoneCountries[$instance->zone_name]);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Pre-builds a `zoneName → [country_ids]` index in `checkDataFile()` instead of iterating all countries/timezones on every insertion
- `whenRecordInserted()` now does a single O(1) lookup + batch attach instead of O(n*m) nested loops
- Also fixes a bug where only the first matching country was attached (due to `continue 2`), now all countries sharing a timezone are attached in one call

Closes #28