### PR TITLE
Use bulk insertion mode for CountriesSeeder

### DIFF
--- a/src/Commands/Seeders/CountriesSeeder.php
+++ b/src/Commands/Seeders/CountriesSeeder.php
@@ -30,8 +30,6 @@ class CountriesSeeder extends BaseSeeder
 
     protected string $model = Country::class;
 
-    protected string $insertionMode = self::INDIVIDUAL_INSERTION_MODE;
-
     public function __construct()
     {
         parent::__construct();


### PR DESCRIPTION
## Summary
- Removed unnecessary `$insertionMode = INDIVIDUAL_INSERTION_MODE` override from `CountriesSeeder`
- No `whenRecordInserted()` callback exists, so bulk insertion is used (~1 query instead of ~250)

Closes #29