### PR TITLE
Convert migrations to anonymous classes

### DIFF
--- a/database/migrations/0000_03_07_190501_create_languages_table.php
+++ b/database/migrations/0000_03_07_190501_create_languages_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateLanguagesTable extends Migration
+return new class extends Migration
 {
     private string $tableName;
 
@@ -39,4 +39,4 @@ class CreateLanguagesTable extends Migration
     {
         Schema::dropIfExists($this->tableName);
     }
-}
+};

--- a/database/migrations/0000_03_07_190502_create_currencies_table.php
+++ b/database/migrations/0000_03_07_190502_create_currencies_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateCurrenciesTable extends Migration
+return new class extends Migration
 {
     private string $tableName;
 
@@ -41,4 +41,4 @@ class CreateCurrenciesTable extends Migration
     {
         Schema::dropIfExists($this->tableName);
     }
-}
+};

--- a/database/migrations/0000_03_07_190503_create_regions_table.php
+++ b/database/migrations/0000_03_07_190503_create_regions_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateRegionsTable extends Migration
+return new class extends Migration
 {
     private string $tableName;
 
@@ -39,4 +39,4 @@ class CreateRegionsTable extends Migration
     {
         Schema::dropIfExists($this->tableName);
     }
-}
+};

--- a/database/migrations/0000_03_07_190504_create_subregions_table.php
+++ b/database/migrations/0000_03_07_190504_create_subregions_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSubregionsTable extends Migration
+return new class extends Migration
 {
     private string $tableName;
 
@@ -44,4 +44,4 @@ class CreateSubregionsTable extends Migration
     {
         Schema::dropIfExists($this->tableName);
     }
-}
+};

--- a/database/migrations/0000_03_07_190506_create_countries_table.php
+++ b/database/migrations/0000_03_07_190506_create_countries_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateCountriesTable extends Migration
+return new class extends Migration
 {
     private string $tableName;
 
@@ -62,4 +62,4 @@ class CreateCountriesTable extends Migration
     {
         Schema::dropIfExists($this->tableName);
     }
-}
+};

--- a/database/migrations/0000_03_07_190507_create_states_table.php
+++ b/database/migrations/0000_03_07_190507_create_states_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateStatesTable extends Migration
+return new class extends Migration
 {
     private string $tableName;
 
@@ -47,4 +47,4 @@ class CreateStatesTable extends Migration
     {
         Schema::dropIfExists($this->tableName);
     }
-}
+};

--- a/database/migrations/0000_03_07_190508_create_cities_table.php
+++ b/database/migrations/0000_03_07_190508_create_cities_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateCitiesTable extends Migration
+return new class extends Migration
 {
     private string $tableName;
 
@@ -54,4 +54,4 @@ class CreateCitiesTable extends Migration
     {
         Schema::dropIfExists($this->tableName);
     }
-}
+};

--- a/database/migrations/0000_03_07_190509_create_timezones_table.php
+++ b/database/migrations/0000_03_07_190509_create_timezones_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateTimezonesTable extends Migration
+return new class extends Migration
 {
     private string $tableName;
 
@@ -39,4 +39,4 @@ class CreateTimezonesTable extends Migration
     {
         Schema::dropIfExists($this->tableName);
     }
-}
+};

--- a/database/migrations/0000_03_07_190510_create_countries_timezones_table.php
+++ b/database/migrations/0000_03_07_190510_create_countries_timezones_table.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateCountriesTimezonesTable extends Migration
+return new class extends Migration
 {
     private string $tableName;
 
@@ -39,4 +39,4 @@ class CreateCountriesTimezonesTable extends Migration
     {
         Schema::dropIfExists($this->tableName);
     }
-}
+};


### PR DESCRIPTION
## Summary
- Convert all 9 migration files from named classes to anonymous classes (Laravel 9+ standard)
- Prevents PHP fatal errors from class name collisions when users have their own migrations with the same names

Closes #35

## Test plan
- [x] Verify `php artisan migrate` runs successfully
- [x] Verify `php artisan migrate:rollback` works correctly