### PR TITLE
Add database indexes on frequently queried columns

### DIFF
--- a/database/migrations/0000_03_07_190506_create_countries_table.php
+++ b/database/migrations/0000_03_07_190506_create_countries_table.php
@@ -52,6 +52,9 @@ class CreateCountriesTable extends Migration
             $table->string('longitude', 15);
             $table->string('emoji', 40);
             $table->string('emojiU', 40);
+
+            $table->index('iso2');
+            $table->index('iso3');
         });
     }
 

--- a/database/migrations/0000_03_07_190507_create_states_table.php
+++ b/database/migrations/0000_03_07_190507_create_states_table.php
@@ -37,6 +37,8 @@ class CreateStatesTable extends Migration
             $table->string('type')->nullable();
             $table->string('latitude')->nullable();
             $table->string('longitude')->nullable();
+
+            $table->index('state_code');
         });
     }
 

--- a/database/migrations/0000_03_07_190508_create_cities_table.php
+++ b/database/migrations/0000_03_07_190508_create_cities_table.php
@@ -44,6 +44,8 @@ class CreateCitiesTable extends Migration
             $table->string('latitude');
             $table->string('longitude');
             $table->string('wiki_data_id')->nullable();
+
+            $table->index('name');
         });
     }
 


### PR DESCRIPTION
## Summary
- Add index on `iso2` and `iso3` in countries migration
- Add index on `state_code` in states migration
- Add index on `name` in cities migration (~150k+ rows, biggest benefit)

Note: cities already had indexes on `state_id` and `country_id`.

Closes #38

## Test plan
- [x] Verify `php artisan migrate` creates the indexes
- [x] Verify queries like `Country::where('iso2', 'ES')` use the index