### PR TITLE
Make country native field required with name fallback.

### DIFF
--- a/database/migrations/0000_03_07_190506_create_countries_table.php
+++ b/database/migrations/0000_03_07_190506_create_countries_table.php
@@ -39,7 +39,7 @@ return new class extends Migration
             }
 
             $table->string('tld', 8);
-            $table->string('native', 80)->nullable();
+            $table->string('native', 80);
             $table->string('region', 80);
 
             if (config()->boolean('atlas.entities.regions')) {

--- a/database/migrations/0000_03_07_190513_make_country_native_required.php
+++ b/database/migrations/0000_03_07_190513_make_country_native_required.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Enforces a non-null `native` on the countries table. Databases that
+     * were migrated before this constraint existed may hold null natives,
+     * so those rows are first backfilled from `name` (mirroring the seeder's
+     * `native ?? name` fallback) to guarantee the NOT NULL change succeeds.
+     * Every step is guarded so the migration is safe on both fresh installs
+     * and upgrades.
+     */
+    public function up(): void
+    {
+        if (! config()->boolean('atlas.entities.countries')) {
+            return;
+        }
+
+        $countriesTable = config()->string('atlas.countries_tablename');
+
+        if (! Schema::hasTable($countriesTable) || ! Schema::hasColumn($countriesTable, 'native')) {
+            return;
+        }
+
+        // Backfill existing NULLs with the country name so the NOT NULL
+        // change cannot fail on already-seeded production databases.
+        DB::table($countriesTable)
+            ->whereNull('native')
+            ->update(['native' => DB::raw(DB::getQueryGrammar()->wrap('name'))]);
+
+        Schema::table($countriesTable, function (Blueprint $table): void {
+            $table->string('native', 80)->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * Restores the nullable definition; existing data is left untouched.
+     */
+    public function down(): void
+    {
+        if (! config()->boolean('atlas.entities.countries')) {
+            return;
+        }
+
+        $countriesTable = config()->string('atlas.countries_tablename');
+
+        if (! Schema::hasTable($countriesTable) || ! Schema::hasColumn($countriesTable, 'native')) {
+            return;
+        }
+
+        Schema::table($countriesTable, function (Blueprint $table): void {
+            $table->string('native', 80)->nullable()->change();
+        });
+    }
+};

--- a/resources/json/countries.json
+++ b/resources/json/countries.json
@@ -3146,7 +3146,7 @@
         "currency_name": "West African CFA franc",
         "currency_symbol": "CFA",
         "tld": ".ci",
-        "native": null,
+        "native": "Côte d'Ivoire",
         "region": "Africa",
         "region_id": 1,
         "subregion": "Western Africa",

--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string|null           $capital
  * @property string|null           $currency_code
  * @property string                $tld
- * @property string|null           $native
+ * @property string                $native
  * @property string                $region_name
  * @property int|null              $region_id
  * @property string|null           $subregion_name
@@ -147,7 +147,7 @@ class Country extends BaseModel
             'phonecode'      => $jsonItem['phonecode'],
             'capital'        => $jsonItem['capital'],
             'tld'            => $jsonItem['tld'],
-            'native'         => $jsonItem['native'],
+            'native'         => $jsonItem['native'] ?? $jsonItem['name'],
             'region_name'    => $jsonItem['region'],
             'subregion_name' => $jsonItem['subregion'],
             'nationality'    => $jsonItem['nationality'],

--- a/tests/Feature/Migrations/SchemaTest.php
+++ b/tests/Feature/Migrations/SchemaTest.php
@@ -29,6 +29,14 @@ describe('Countries table schema', function () {
         expect($currencyCode['nullable'])->toBeTrue();
     });
 
+    it('has native as a non-nullable column', function () {
+        $columns = Schema::getColumns('countries');
+        $native  = collect($columns)->firstWhere('name', 'native');
+
+        expect($native)->not->toBeNull();
+        expect($native['nullable'])->toBeFalse();
+    });
+
     it('has region_name column instead of region', function () {
         $columns = Schema::getColumns('countries');
 

--- a/tests/Feature/Models/ModelConfigTest.php
+++ b/tests/Feature/Models/ModelConfigTest.php
@@ -21,6 +21,7 @@ describe('Translations cast', function () {
             'numeric_code' => '999',
             'phonecode'    => '99',
             'tld'          => '.ts',
+            'native'       => 'Test',
             'region_name'  => 'Test Region',
             'nationality'  => 'Tester',
             'translations' => json_encode(['en' => 'Test']),


### PR DESCRIPTION
The `native` field on countries is now required instead of nullable. If the source JSON doesn't provide a value for `native`, the `name` field is automatically used as a fallback.

## Changes

- **Migration**: `native` is no longer `nullable()`
- **Country model**: `fromJsonToDBRecord()` uses `$jsonItem['native'] ?? $jsonItem['name']`
- **PHPDoc**: Type updated from `string|null` to `string`
- **Tests**: Added required `native` field in translations test

## Rationale

Ensures all countries always have a native name available, simplifying data consumption without needing to handle null values.