### PR TITLE
Support Laravel 12.60+/13.10+ only, drop EOL Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,15 +32,15 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.3', '8.4']
-        laravel: ['11.*']
-        testbench: ['9.*']
+        laravel: ['12.*']
+        testbench: ['10.*']
         include:
           - php: '8.3'
-            laravel: '12.*'
-            testbench: '10.*'
+            laravel: '13.*'
+            testbench: '11.*'
           - php: '8.4'
-            laravel: '12.*'
-            testbench: '10.*'
+            laravel: '13.*'
+            testbench: '11.*'
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ With 'Atlas' you will be able to create new tables in the database and fill them
 ## Requirements
 
 - PHP 8.3+
-- Laravel 11+
+- Laravel 12+
 
 
 ## Get to know us

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "homepage": "https://github.com/RaiolaNetworks/Atlas",
     "require": {
         "php": "^8.3",
-        "laravel/framework": "^11.0|^12.0",
+        "laravel/framework": "^12.60|^13.10",
         "laravel/prompts": "^0.3",
         "halaxa/json-machine": "^1.0"
     },
@@ -36,10 +36,10 @@
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1",
-        "orchestra/testbench": "^9.5|^10.0",
-        "pestphp/pest": "^3.5",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0"
+        "orchestra/testbench": "^10.0|^11.0",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-arch": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Qué hace

Moderniza el rango de versiones de Laravel soportadas por Atlas.

### 🔒 Seguridad
- Sube los suelos a **`^12.60`** y **`^13.10`**, que excluyen todas las versiones afectadas por **GHSA-5vg9-5847-vvmq** (CRLF injection en la regla de email por defecto). Resuelve la alerta de Dependabot sobre `composer.json`.

### ➕ Añadido
- **Soporte para Laravel 13**: `orchestra/testbench ^11` y el ecosistema **Pest 4** (`pest`, `pest-plugin-arch`, `pest-plugin-laravel`), primera línea compatible con L13.
- Matriz de CI ampliada a Laravel 13 (testbench 11) en PHP 8.3 y 8.4.

### ➖ Eliminado (breaking)
- **Se retira Laravel 11**: su soporte de seguridad terminó el **2026-03-12** (EOL). El paquete deja de apuntar a un framework sin parches.
- Filas de L11 / testbench 9 eliminadas de la matriz de CI.

### Constraints resultantes
```
"laravel/framework": "^12.60|^13.10"
"orchestra/testbench": "^10.0|^11.0"
"pestphp/pest" (+plugins): "^4.0"
"php": "^8.3"   (sin cambios)
```

## Impacto
- ⚠️ **Cambio incompatible** → debe publicarse como **major (v3)** de Atlas.

## Verificación
- ✅ 151 tests (263 asserts) pasan en Laravel 13.
- ✅ PHPStan sin errores.
- ✅ `composer audit` limpio.
- ✅ `composer validate` OK.
