### PR TITLE
Require CRLF-patched Laravel 12.60+ (keep Laravel 11)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "homepage": "https://github.com/RaiolaNetworks/Atlas",
     "require": {
         "php": "^8.3",
-        "laravel/framework": "^11.0|^12.0",
+        "laravel/framework": "^11.0|^12.60",
         "laravel/prompts": "^0.3",
         "halaxa/json-machine": "^1.0"
     },


### PR DESCRIPTION
## Qué hace
Sube el suelo de `laravel/framework` a **`^11.0|^12.60`** para que el paquete no pueda resolver ninguna versión afectada por **GHSA-5vg9-5847-vvmq** (CRLF injection, afecta a `< 12.60.0`). Cierra la alerta de Dependabot en `composer.json`.

## No-breaking (a propósito)
- Mantiene **Laravel 11** (`^11.0`): v11 no está en el rango afectado. Pensado para la línea **2.x** actual, sin forzar major.

## Relación con otros PRs
- ⚠️ **Solaparía con #68** (que sube a `^12.60|^13.10` y elimina L11 → v3). Ambos tocan la misma línea de `composer.json`. Este PR es para 2.x **ahora**; #68 es la **v3** futura que lo supersede. Mergear este primero; al mergear #68 después habrá que resolver ese conflicto (gana #68).

## Verificación
- `composer why-not laravel/framework 12.59.0` → excluida por la constraint.
- `composer audit` limpio (instalado 12.64).
- 151 tests ✓, `composer validate` OK.